### PR TITLE
Release MIDI convert to CC v5.1.1

### DIFF
--- a/Utility/mschnell_MIDI Convert to CC.jsfx
+++ b/Utility/mschnell_MIDI Convert to CC.jsfx
@@ -1,12 +1,17 @@
 desc: MIDI convert to CC
 author: Michael Schnell (mschnell@bschnell.de)
-version: 5.1
-changelog: Enhanced pass-through functionality
+version: 5.1.1
+changelog:
+  Fix syntax error that stopped script from loading
+  Fix bug that made it impossible to enable passthrough
+  Expose enhanced pass-through options in `slider10`
+  (Warning: doesn't implement the missing enhanced passthrough logic)
+screenshot: https://i.imgur.com/JkBjpH5.png
 donation: United Nations Foundation http://www.unfoundation.org/
 about:
   ## Description
 
-    Midi CC, PC, Note On, Note Off, Pitch Bend or After Touch messages are converted to Midi CC messages with a predefined Channel and CC #. The CC value is calculated from the incoming value. 
+    Midi CC, PC, Note On, Note Off, Pitch Bend or After Touch messages are converted to Midi CC messages with a predefined Channel and CC #. The CC value is calculated from the incoming value.
 
   Midi messages that don't fit the "In" specifications are passed through according to the setting of the drop-down menu.
 
@@ -22,9 +27,9 @@ about:
 
     The slider "Out CC" defines the Midi CC message # to be sent
 
-    The slider "Min CC Value" defines the value to be sent when the Min Input Value is received. Hence there will be an offset of Min_Input_Value - Min_Outout_Value. 
+    The slider "Min CC Value" defines the value to be sent when the Min Input Value is received. Hence there will be an offset of Min_Input_Value - Min_Outout_Value.
 
-    The slider "Max CC Value" defines the value to be sent when the Max Input Value is received. Hence there will be an appropriate stretching of the input range. 
+    The slider "Max CC Value" defines the value to be sent when the Max Input Value is received. Hence there will be an appropriate stretching of the input range.
 
     TODO: hysteresis with Pitch Bend input; high resolution CC
 
@@ -32,21 +37,21 @@ about:
 
 slider1:0<0,16,1{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,all}>In Channel
 slider2:0<0,6,1{CC,PC,Note On,Note Off,Note On Velocity,Note Off Velocity,Pitch Bend,After Touch}>MIDI Message
-slider3:1<0,128,1{0 Bank Sel M,1 Mod Wheel M,2 Breath M,3,4 Foot P M,5 Porta M,6 Data Entry M,7 Vol M,8 Balance M,9,10 Pan M,11 Expression M,12 Ctrl 1 M,13 Ctrl 2 M,14,15,16 GP Slider 1,17 GP Slider 2,18 GP Slider 3,19 GP Slider 4,20,21,22,23,24,25,26,27,28,29,30,31,32 Bank Sel L,33 Mod Wheel L,34 Breath L,35,36 Foot P L,37 Porta L,38 Data Entry L,39 Vol L,40 Balance L,41,42 Pan L,43 Expression L,44 Ctrl 1 L,45 Ctrl 2 L,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 Hold P sw,65 Porta sw,66 Sustenuto sw,67 Soft P sw,68 Legato P sw,69 Hold 2 P sw,70 S.Variation,71 S.Timbre,72 S.Release,73 S.Attack,74 S.Brightness,75 S.Ctrl 6,76 S.Ctrl 7,77 S.Ctrl 8,78 S.Ctrl 9,79 S.Ctrl 10,80 GP B.1 sw,81 GP B.2 sw,82 GP B.3 sw,83 GP B.4 sw,84,85,86,87,88,89,90,91 Effects Lv,92 Trem Lv,93 Chorus Lv,94 Celeste Lv,95 Phaser Lv,96 Data B. Inc,97 Data B. Dec,98 NRP L,99 NRP M,100 RP L,101 RP M,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,N/A}>In CC# 
+slider3:1<0,128,1{0 Bank Sel M,1 Mod Wheel M,2 Breath M,3,4 Foot P M,5 Porta M,6 Data Entry M,7 Vol M,8 Balance M,9,10 Pan M,11 Expression M,12 Ctrl 1 M,13 Ctrl 2 M,14,15,16 GP Slider 1,17 GP Slider 2,18 GP Slider 3,19 GP Slider 4,20,21,22,23,24,25,26,27,28,29,30,31,32 Bank Sel L,33 Mod Wheel L,34 Breath L,35,36 Foot P L,37 Porta L,38 Data Entry L,39 Vol L,40 Balance L,41,42 Pan L,43 Expression L,44 Ctrl 1 L,45 Ctrl 2 L,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 Hold P sw,65 Porta sw,66 Sustenuto sw,67 Soft P sw,68 Legato P sw,69 Hold 2 P sw,70 S.Variation,71 S.Timbre,72 S.Release,73 S.Attack,74 S.Brightness,75 S.Ctrl 6,76 S.Ctrl 7,77 S.Ctrl 8,78 S.Ctrl 9,79 S.Ctrl 10,80 GP B.1 sw,81 GP B.2 sw,82 GP B.3 sw,83 GP B.4 sw,84,85,86,87,88,89,90,91 Effects Lv,92 Trem Lv,93 Chorus Lv,94 Celeste Lv,95 Phaser Lv,96 Data B. Inc,97 Data B. Dec,98 NRP L,99 NRP M,100 RP L,101 RP M,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,N/A}>In CC#
 slider4:0<0,127,1)>Min Input Value
 slider5:127<0,127,1)>Max Input Value
 slider6:0<0,16,1{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,same as received}>Out Channel
-slider7:1<0,127,1{0 Bank Sel M,1 Mod Wheel M,2 Breath M,3,4 Foot P M,5 Porta M,6 Data Entry M,7 Vol M,8 Balance M,9,10 Pan M,11 Expression M,12 Ctrl 1 M,13 Ctrl 2 M,14,15,16 GP Slider 1,17 GP Slider 2,18 GP Slider 3,19 GP Slider 4,20,21,22,23,24,25,26,27,28,29,30,31,32 Bank Sel L,33 Mod Wheel L,34 Breath L,35,36 Foot P L,37 Porta L,38 Data Entry L,39 Vol L,40 Balance L,41,42 Pan L,43 Expression L,44 Ctrl 1 L,45 Ctrl 2 L,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 Hold P sw,65 Porta sw,66 Sustenuto sw,67 Soft P sw,68 Legato P sw,69 Hold 2 P sw,70 S.Variation,71 S.Timbre,72 S.Release,73 S.Attack,74 S.Brightness,75 S.Ctrl 6,76 S.Ctrl 7,77 S.Ctrl 8,78 S.Ctrl 9,79 S.Ctrl 10,80 GP B.1 sw,81 GP B.2 sw,82 GP B.3 sw,83 GP B.4 sw,84,85,86,87,88,89,90,91 Effects Lv,92 Trem Lv,93 Chorus Lv,94 Celeste Lv,95 Phaser Lv,96 Data B. Inc,97 Data B. Dec,98 NRP L,99 NRP M,100 RP L,101 RP M,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127}>Out CC# 
+slider7:1<0,127,1{0 Bank Sel M,1 Mod Wheel M,2 Breath M,3,4 Foot P M,5 Porta M,6 Data Entry M,7 Vol M,8 Balance M,9,10 Pan M,11 Expression M,12 Ctrl 1 M,13 Ctrl 2 M,14,15,16 GP Slider 1,17 GP Slider 2,18 GP Slider 3,19 GP Slider 4,20,21,22,23,24,25,26,27,28,29,30,31,32 Bank Sel L,33 Mod Wheel L,34 Breath L,35,36 Foot P L,37 Porta L,38 Data Entry L,39 Vol L,40 Balance L,41,42 Pan L,43 Expression L,44 Ctrl 1 L,45 Ctrl 2 L,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64 Hold P sw,65 Porta sw,66 Sustenuto sw,67 Soft P sw,68 Legato P sw,69 Hold 2 P sw,70 S.Variation,71 S.Timbre,72 S.Release,73 S.Attack,74 S.Brightness,75 S.Ctrl 6,76 S.Ctrl 7,77 S.Ctrl 8,78 S.Ctrl 9,79 S.Ctrl 10,80 GP B.1 sw,81 GP B.2 sw,82 GP B.3 sw,83 GP B.4 sw,84,85,86,87,88,89,90,91 Effects Lv,92 Trem Lv,93 Chorus Lv,94 Celeste Lv,95 Phaser Lv,96 Data B. Inc,97 Data B. Dec,98 NRP L,99 NRP M,100 RP L,101 RP M,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127}>Out CC#
 slider8:0<0,127,1)>Min CC Value
 slider9:127<0,127,1)>Max CC Value
-slider10:1<0,1,1{off,on}>pass through unmodified messages
+slider10:3<0,3,1{off,Pass through unconverted,Pass through converted,Pass through all}>Pass through messages
 
 @slider
   inchannel = slider1;
-  inchannel > 15 ? (          // all 
+  inchannel > 15 ? (          // all
     inmask = 0xf0;
     inchannel = 0;
-   ) : ( 
+   ) : (
     inmask = 0xff;
   );
   m11 = -1;
@@ -66,39 +71,39 @@ slider10:1<0,1,1{off,on}>pass through unmodified messages
     slider3 = 128;
    ) : type == 3 ? (          // Note Off
     m1 = 0x80 + inchannel;
-    m11= 0x90 + inchannel; 
+    m11= 0x90 + inchannel;
     slider3 = 128;
-   ) : type == 4 ? (          // Note On
+   ) : type == 4 ? (          // Note On Velocity
     m1 = 0x90 + inchannel;
     slider3 = 128;
-   ) : type == 5 ? (          // Note Off
+   ) : type == 5 ? (          // Note Off Velocity
     m1 = 0x80 + inchannel;
    ) : type == 6 ? (          // Pitch Bend
     m1 = 0xE0 + inchannel;
     slider3 = 128;
    ) : type == 7 ? (          // After Touch
     m1 = 0xD0 + inchannel;
-    slider3 = 128;    
-  );   
+    slider3 = 128;
+  );
   inmin = slider4;
   inmax = slider5;
   inmin >= inmax ? (
     inmax = inmin+1;
     slider5 = inmax;
-  );  
+  );
   inmax  = slider5;
   outchannel = slider6;
   outchannel > 15 ? (         // "same"
     mm1    = 0xb0;
-   ) : ( 
+   ) : (
     mm1    = 0xb0 + outchannel;
-  ); 
+  );
   outCC   = slider7;
   outmin  = slider8;
   outmax  = slider9;
   factor  = (outmax-outmin) / (inmax - inmin);
   inmax2  = inmax;
-  inmax2  == 127 ? inmax2  = 127 + (127/128);           // supposedly 127 is meant as maximim 
+  inmax2  == 127 ? inmax2  = 127 + (127/128);           // supposedly 127 is meant as maximim
   factor2 = (outmax-outmin) / (inmax2 - inmin);
 @block
 
@@ -111,8 +116,8 @@ function convert2 (mlow, mhigh) (
       m3 > 127 ? m3 = 127;
       m  = mm1;
       msg11 = -1;
-    );  
-  );  
+    );
+  );
 );
 
 function convert (mm) (
@@ -122,8 +127,8 @@ function convert (mm) (
       m3 > 127 ? m3 = 127;
       m  = mm1;
       msg11 = -1;
-    );  
-  );  
+    );
+  );
 );
 
   while (midirecv(offset, msg1, msg2, msg3)) (
@@ -134,49 +139,47 @@ function convert (mm) (
       msg11 == m1 ? (
         msg2 == m2 ? (
           convert(msg3);
-        );  
+        );
       );
-     ) : type == 3 ? (                           // Note off 
-      msg11 == m1 ? ( 
+     ) : type == 3 ? (                           // Note off
+      msg11 == m1 ? (
         convert(msg2);
        ) : (msg11 == m11) && (msg3 == 0) ? (     // Note On, Velocity 0 -> Note off
         convert(msg2);
-      );   
+      );
      ) : type == 2 ? (                           // Note On
-      msg11 == m1 ? ( 
+      msg11 == m1 ? (
         msg3 != 0 ? (                            // Velocity 0 -> Note off
           convert(msg2);
-        );  
-      );   
+        );
+      );
      ) : (type == 4) || (type == 5) ? (          // Note On or Off
       msg11 == m1 ? (
-        convert(msg3);                
-      );      
+        convert(msg3);
+      );
      ) : type == 6 ? (                           // Pich Bend
       msg11 == m1 ? (
-        convert2(msg2, msg3);                
-      );      
+        convert2(msg2, msg3);
+      );
      ) : (type == 1) || (type == 7) ? (           // Program Change or After Touch
       msg11 == m1 ? (
-        convert(msg2);                
-      );      
-    );     
+        convert(msg2);
+      );
+    );
     m  ?  (
       outchannel > 15 ? (
         m = m | (msg1 & 0x0f);                   // replace predefined channel by received channel
       );
-      midisend(offset, m,    outCC,   m3); 
-    );  
-    !slider10 ? (                                // no passthrough 
+      midisend(offset, m,    outCC,   m3);
+    );
+    !slider10 ? (                                // no passthrough
       msg11 = -1;
      ) :  slider10 == 1 ? (                      // pass through unconverted
-      0;     
+      0;
      ) :  slider10 == 2 ? (                      // pass though converted
-      msg11 < 0 ? msg11 = 0 : msg11 = -1;     
-     ) :  slider10 == 3 ? (                      // pass thoug all
-      msg11 = 0;     
-     ); 
-    msg11 >= 0 ?  midisend(offset, msg1, msg2,  msg3); // pass through  
-  );
-    msg11 >= 0 ?  midisend(offset, msg1, msg2,  msg3); // pass through  
+      msg11 < 0 ? msg11 = 0 : msg11 = -1;
+     ) :  slider10 == 3 ? (                      // pass though all
+      msg11 = 0;
+     );
+    msg11 >= 0 ?  midisend(offset, msg1, msg2,  msg3); // pass through
   );


### PR DESCRIPTION
Fix syntax error that stopped script from loading
Fix bug that made it impossible to enable passthrough
Expose enhanced pass-through options in `slider10`
(Warning: doesn't implement the missing enhanced passthrough logic)