### PR TITLE
Fix computation of track average in Automixer

### DIFF
--- a/Utility/CoreyScogin_AutoMixer.jsfx
+++ b/Utility/CoreyScogin_AutoMixer.jsfx
@@ -1,6 +1,6 @@
 desc:AutoMixer
 author: Corey Scogin
-version: 1.3
+version: 1.3.1
 tags: volume, attenuation, automation
 link: Forum Thread https://forum.cockos.com/showthread.php?t=173289
 about: 
@@ -14,7 +14,7 @@ about:
   - Inactive channels will be attenuated helping to decrease background noise.
   - Multiple active channels will be attenuated according to the sum of all channels helping to keep the overall volume under control.
   See [Wikipedia](https://en.wikipedia.org/wiki/Automixer) for a more thorough description.
-changelog: More instance count tracking improvements. Now supports jumping playback position while playing.
+changelog: Fix subtle bug in multichannel tracks: If the channels have destructive interference the Automixer no longer thinks they’re silent.
 
 // Known Bugs:
 //  - Playback must be stopped and started if an instance is bypassed, added, or removed.

--- a/Utility/CoreyScogin_AutoMixer.jsfx
+++ b/Utility/CoreyScogin_AutoMixer.jsfx
@@ -79,7 +79,7 @@ slider3:WindowType=0<0,1,1{Rectangular,Efficient}>RMS Window Type
   i=0;
   trkSum=0;
   loop(num_ch,              // For each channel
-        trkSum += spl(i);   // Add the sample values
+        trkSum += sqr(spl(i));   // Add the sample values
         i += 1;
        ); 
   trkAvg = trkSum / num_ch; // Calculate the average
@@ -88,10 +88,9 @@ slider3:WindowType=0<0,1,1{Rectangular,Efficient}>RMS Window Type
   // Calculate the new rms value
   WindowType == 0 ? (          // Window Type == Rectangular
                             // Less efficient true rectangular window moving average 
-    splSq = trkAvg ^ 2;     // Sample (or average of channel samples) squared for moving average sum.
     rmsSum -= buf[0];       // Subtract the oldest value square from the sum
-    rmsSum += splSq;        // add the newest value square to the sum
-    buf[0] = splSq;         // add the newest value square to the buffer
+    rmsSum += trkAvg;        // add the newest value square to the sum
+    buf[0] = trkAvg;         // add the newest value square to the buffer
   
     (buf+=1) >= window ? buf=0;   // increment buffer position
   
@@ -99,7 +98,7 @@ slider3:WindowType=0<0,1,1{Rectangular,Efficient}>RMS Window Type
     
   ):( // Window Type == efficient approximation 
     // Efficient moving average approximation
-    fout = a0 * (trkAvg ^ 2) + b1 * fout;
+    fout = a0 * trkAvg + b1 * fout;
     rms = sqrt(fout);
   );
   


### PR DESCRIPTION
Currently, the track average is computed by adding the channels. This works most of the time, because the signal in the channels are similar (most often they’re mono, really), which is probably why this bug wasn’t noticed until now. But there are cases in which the channels are out-of-phase, and adding them together will result in destructive interference. Still, the channels are producing sound, and shouldn’t be muted by the automixer.

The solution is to add the channels **after squaring them**. This gets rid of the negative values.

In other words: we add up the channels on the power domain, not the amplitude domain.

See the example project on this Pull Request for a pathological case in which one of the aumixed microphones is a stereo signal in which the left and right channels are perfectly out-of-phase. The current automixer mutes that track. The fixed version I’m proposing mixes the track correctly.

[automixer-bug-example.zip](https://github.com/ReaTeam/JSFX/files/5399115/automixer-bug-example.zip)

See also http://replaygain.hydrogenaud.io/proposal/rms_energy.html