### PR TITLE
Release MIDI Fret and Pick v1.03

### DIFF
--- a/MIDI/juan_r_MIDI Fret and Pick.jsfx
+++ b/MIDI/juan_r_MIDI Fret and Pick.jsfx
@@ -1,9 +1,13 @@
 desc: MIDI Fret and Pick
 author: Juan_R
-version: 1.02
-changelog: improved "about" docs
+version: 1.03
+changelog:
+  1.00  initial release
+  1.01  clean code, add idle option: mixed recycle+octave
+  1.02  improved "about" docs
+  1.03  added options to make fretting notes play immediately
 about:
-  # MIDI Fret and Pick (Juan_R)
+  # MIDI Fret and pick (Juan_R)
 
   Create two ranges on the keyboard:
   The fretting range and the picking range.
@@ -14,7 +18,7 @@ about:
   option to discard, recycle through the same fretted notes, recycle at ascending octaves, or mixed recycle+octaves.
 
   This plugin is left-right hand agnostic: picking and fretting range can be on either side,
-  as long as they do not overlap, which can cause unpredictable results.
+  and even overlap, although in this case the results might not make too much sense.
 
   The fretting range can be arbitrarily transposed, so that any range of notes can be reached,
   no matter where the range actually is on the keyboard.
@@ -29,8 +33,9 @@ slider2:FRH=59<0,127,1{0: C-1,1: C#-1,2: D-1,3: D#-1,4: E-1,5: F-1,6: F#-1,7: G-
 slider3:FRT=0<-88,88,1>Fretting range transpose
 slider4:PRL=60<0,127,1{0: C-1,1: C#-1,2: D-1,3: D#-1,4: E-1,5: F-1,6: F#-1,7: G-1,8: G#-1,9: A-1,10: A#-1,11: B-1,12: C0,13: C#0,14: D0,15: D#0,16: E0,17: F0,18: F#0,19: G0,20: G#0,21: A0,22: A#0,23: B0,24: C1,25: C#1,26: D1,27: D#1,28: E1,29: F1,30: F#1,31: G1,32: G#1,33: A1,34: A#1,35: B1,36: C2,37: C#2,38: D2,39: D#2,40: E2,41: F2,42: F#2,43: G2,44: G#2,45: A2,46: A#2,47: B2,48: C3,49: C#3,50: D3,51: D#3,52: E3,53: F3,54: F#3,55: G3,56: G#3,57: A3,58: A#3,59: B3,60: C4,61: C#4,62: D4,63: D#4,64: E4,65: F4,66: F#4,67: G4,68: G#4,69: A4,70: A#4,71: B4,72: C5,73: C#5,74: D5,75: D#5,76: E5,77: F5,78: F#5,79: G5,80: G#5,81: A5,82: A#5,83: B5,84: C6,85: C#6,86: D6,87: D#6,88: E6,89: F6,90: F#6,91: G6,92: G#6,93: A6,94: A#6,95: B6,96: C7,97: C#7,98: D7,99: D#7,100: E7,101: F7,102: F#7,103: G7,104: G#7,105: A7,106: A#7,107: B7,108: C8,109: C#8,110: D8,111: D#8,112: E8,113: F8,114: F#8,115: G8,116: G#8,117: A8,118: A#8,119: B8,120: C9,121: C#9,122: D9,123: D#9,124: E9,125: F9,126: F#9,127: G9}>PICKING range low
 slider5:PRH=127<0,127,1{0: C-1,1: C#-1,2: D-1,3: D#-1,4: E-1,5: F-1,6: F#-1,7: G-1,8: G#-1,9: A-1,10: A#-1,11: B-1,12: C0,13: C#0,14: D0,15: D#0,16: E0,17: F0,18: F#0,19: G0,20: G#0,21: A0,22: A#0,23: B0,24: C1,25: C#1,26: D1,27: D#1,28: E1,29: F1,30: F#1,31: G1,32: G#1,33: A1,34: A#1,35: B1,36: C2,37: C#2,38: D2,39: D#2,40: E2,41: F2,42: F#2,43: G2,44: G#2,45: A2,46: A#2,47: B2,48: C3,49: C#3,50: D3,51: D#3,52: E3,53: F3,54: F#3,55: G3,56: G#3,57: A3,58: A#3,59: B3,60: C4,61: C#4,62: D4,63: D#4,64: E4,65: F4,66: F#4,67: G4,68: G#4,69: A4,70: A#4,71: B4,72: C5,73: C#5,74: D5,75: D#5,76: E5,77: F5,78: F#5,79: G5,80: G#5,81: A5,82: A#5,83: B5,84: C6,85: C#6,86: D6,87: D#6,88: E6,89: F6,90: F#6,91: G6,92: G#6,93: A6,94: A#6,95: B6,96: C7,97: C#7,98: D7,99: D#7,100: E7,101: F7,102: F#7,103: G7,104: G#7,105: A7,106: A#7,107: B7,108: C8,109: C#8,110: D8,111: D#8,112: E8,113: F8,114: F#8,115: G8,116: G#8,117: A8,118: A#8,119: B8,120: C9,121: C#9,122: D9,123: D#9,124: E9,125: F9,126: F#9,127: G9}>PICKING range high
-slider6:APN=0<0,2,1{Black+White keys,White keys,Black keys}>Active picking notes
-slider7:IPN=0<0,2,1{Ignore,Cycle,Octave shift,Mixed cycle+octave}>Idle picking notes mode
+slider6:APN=0<0,2,1{Black+White keys,White keys,Black keys}>Active picking keys
+slider7:IPK=0<0,2,1{Ignore,Cycle,Octave shift,Mixed cycle+octave}>Idle picking keys
+slider8:PFN=1<0,2,1{Never,Only if enough picking keys,Always}>Fretting keys trigger notes
 
 @slider
 
@@ -62,7 +67,8 @@ BlackKeys[1]                // C#
     = BlackKeys[10]         // A#
     = 1;
 
-nFretted = 0;                                               // no fretted notes yet
+nFretted = 0;                                               // no fretted keys yet
+nPicked = 0;                                                // no picked keys yet
 
 function is_note(status) (
     status == 0x90 || status == 0x80;
@@ -78,6 +84,11 @@ function is_noteon(status, vel)     (
 
 function is_noteoff(status, vel) (
     status == 0x80 || (status == 0x90 && vel == 0);
+);
+
+function is_valid(note_number)
+(
+    0 <= note_number && note_number <= 127;
 );
 
 function is_fret_range(notenum) (
@@ -145,9 +156,9 @@ local(i small_offset result) (
 // function calc_note_from_index(k)
 // given an index value k (1-based), compute which of the fretted notes (if any) is to be played
 // function is divided into 4 parts + dispatcher
-// depending on option for idle notes: discard, recycle, recycle at octaves, mixed simple_recycle+octaves
+// depending on option for idle picking keys: discard, recycle, recycle at octaves, mixed simple_recycle+octaves
 
-// IPN=0: discard idle picking notes
+// IPK=0: discard idle picking keys
 function calc_note_from_index_simple(k)
 local (i nmatches found result) (
     (k <= 0 || k > nFretted) ? -1                   // discard indices beyond nFretted (the number of fretted notes)
@@ -169,21 +180,21 @@ local (i nmatches found result) (
     );
 );
 
-// IPN=1: recycle idle picking notes over same fretted notes
+// IPK=1: recycle idle picking keys over same fretted notes
 function calc_note_from_index_cycle(k) (
     (nFretted <= 0 || k <= 0) ? -1
     :
     calc_note_from_index_simple( ((k - 1) % nFretted) + 1);
 );
 
-// IPN=2: recycle, ascending octaves
+// IPK=2: recycle, ascending octaves
 function calc_note_from_index_oct(k)(
     (nFretted <= 0 || k <= 0) ? -1
     :
     calc_note_from_index_simple( ((k - 1) % nFretted) + 1) + 12 * floor ((k-1) / nFretted);
 );
 
-// IPN=3: mixed mode: repeat {recycle, then octave}
+// IPK=3: mixed mode: repeat {recycle, then octave}
 function calc_note_from_index_mixoct(k)(
     (nFretted <= 0 || k <= 0) ? -1
     :
@@ -192,10 +203,10 @@ function calc_note_from_index_mixoct(k)(
 
 // dispatcher: function calc_note_from_index(k)
 function calc_note_from_index(k) (
-    (IPN == 0) ?    calc_note_from_index_simple(k)          // ignore indices beyond nFretted (ignore idle picking notes)
-    : (IPN == 1) ?  calc_note_from_index_cycle(k)           // cycle idle picking notes among fretted notes
-    : (IPN == 2) ?  calc_note_from_index_oct(k)             // octave shift idle picking notes
-    : (IPN == 3) ?  calc_note_from_index_mixoct(k);         // repeat, then octave shift, repeat, octave shift...
+    (IPK == 0) ?    calc_note_from_index_simple(k)          // ignore indices beyond nFretted (ignore idle picking keys)
+    : (IPK == 1) ?  calc_note_from_index_cycle(k)           // cycle idle picking notes among fretted keys
+    : (IPK == 2) ?  calc_note_from_index_oct(k)             // octave shift idle picking keys
+    : (IPK == 3) ?  calc_note_from_index_mixoct(k);         // repeat, then octave shift, repeat, octave shift...
 );
 
 
@@ -206,7 +217,7 @@ while (midirecv(offset, msg1, msg2, msg3))
     status = msg1 & 0xF0;
     channel = msg1 & 0x0F;
     is_not_note(status) ?
-        (midisend(offset, msg1, msg2, msg3))                			    // non-note events go through immediately
+        (midisend(offset, msg1, msg2, msg3))                                // non-note events go through immediately
         // else, we have a note on/off event
         :(
             is_fret_range(msg2) ?
@@ -215,30 +226,45 @@ while (midirecv(offset, msg1, msg2, msg3))
                 (
                     FrettedMap[msg2] = 1;
                     nFretted += 1;
+                    // now play a note if the option PFN grants it
+                    (PFN == 2) ? (                                          // Play Fretted Notes == always?
+                        note_to_play = msg2 + FRT;
+                        is_valid(note_to_play) ? midisend(offset, msg1, note_to_play, msg3);
+                    )
+                    :(PFN == 1)? (                                          // Play Fretted Notes == if enough picking keys?
+                        (nFretted <= nPicked) ? (
+                            note_to_play = msg2 + FRT;
+                            is_valid(note_to_play) ? midisend(offset, msg1, note_to_play, msg3);
+                         );
+                    );
                 )
                 // else, it's a note_off
                 :(
                     FrettedMap[msg2] = 0;
-                    nFretted -=     1;
-                    // play fretting note_off straight away after transposing
+                    nFretted -= 1;
+                    // release: play fretting note_off straight away after transposing
                     note_to_play = msg2 + FRT;
-                    (note_to_play >= 0) ? midisend(offset, msg1, note_to_play, msg3);
+                    is_valid(note_to_play) ? midisend(offset, msg1, note_to_play, msg3);
                 );
             ); // end is_fret_range(msg2)
             is_pick_range(msg2) ?
             (
                 is_noteon(status, msg2) ?                                   // note on: calculate the note to play
                 (
+                    nPicked += 1;
                     pick_index = calc_pick_index(msg2);
                     note_to_play = calc_note_from_index(pick_index + 1);    // 1-based vs. 0-based, hence the "+ 1"
-                    (note_to_play >= 0) ? (
+                    is_valid(note_to_play) ? (
                         note_to_play += FRT;                                // transpose fretted range if needed
-                        midisend(offset, msg1, note_to_play, msg3);
-                        PickedMap[msg2] = note_to_play;                     // remember which note we played for this key
+                        is_valid(note_to_play) ? (
+                            midisend(offset, msg1, note_to_play, msg3);
+                            PickedMap[msg2] = note_to_play;                 // remember which note we played for this key
+                        );
                     );
                 )
                 : (                                                         // note off: just turn off the already sounding note
                     midisend(offset, status, PickedMap[msg2], msg3);
+                    nPicked -= 1;
                 );
             ); // end is_pick_range(msg2)
         ); // end else, we have a note on/off event

--- a/MIDI/juan_r_MIDI Fret and Pick.jsfx
+++ b/MIDI/juan_r_MIDI Fret and Pick.jsfx
@@ -1,11 +1,7 @@
 desc: MIDI Fret and Pick
 author: Juan_R
 version: 1.03
-changelog:
-  1.00  initial release
-  1.01  clean code, add idle option: mixed recycle+octave
-  1.02  improved "about" docs
-  1.03  added options to make fretting notes play immediately
+changelog: added options to make fretting notes play immediately
 about:
   # MIDI Fret and pick (Juan_R)
 


### PR DESCRIPTION
1.00  initial release
1.01  clean code, add idle option: mixed recycle+octave
1.02  improved "about" docs
1.03  added options to make fretting notes play immediately